### PR TITLE
Refactor tests to jest structure

### DIFF
--- a/test/logUtils.test.js
+++ b/test/logUtils.test.js
@@ -4,29 +4,24 @@ const assert = require('assert'); //built-in assertion library
 const { logStart, logReturn } = require('../lib/logUtils'); //functions under test
 const { mockConsole } = require('../utils/mockConsole'); //capture console output
 
-function runTest(desc, testFn) {
-  try {
-    testFn();
-    console.log(`\u2713 ${desc}`); //success indicator
-  } catch (err) {
-    console.error(`\u2717 ${desc}`); //failure indicator
-    console.error(err);
-    process.exitCode = 1; //signal test failure
-  }
-}
+describe('logUtils', () => { // (group log utility tests)
+  let spy; // (console spy holder)
 
-runTest('logStart logs correct start message', () => {
-  const spy = mockConsole('log'); //replace console.log
-  logStart('fn', 1, 2); //trigger log
-  const last = spy.mock.calls.length - 1; //index of our log entry
-  assert.strictEqual(spy.mock.calls[last][0], '[START] fn(1, 2)'); //check output
-  spy.mockRestore(); //restore console.log
-});
+  afterEach(() => { // (restore console after each test)
+    spy.mockRestore(); // (restore console.log)
+  });
 
-runTest('logReturn logs correct return message', () => {
-  const spy = mockConsole('log'); //replace console.log
-  logReturn('fn', 'value'); //trigger log
-  const last = spy.mock.calls.length - 1; //index of our log entry
-  assert.strictEqual(spy.mock.calls[last][0], '[RETURN] fn -> "value"'); //check output
-  spy.mockRestore(); //restore console.log
+  test('logStart logs correct start message', () => { // (verify logStart output)
+    spy = mockConsole('log'); // (replace console.log)
+    logStart('fn', 1, 2); // (trigger log)
+    const last = spy.mock.calls.length - 1; // (index of our log entry)
+    assert.strictEqual(spy.mock.calls[last][0], '[START] fn(1, 2)'); // (check output)
+  });
+
+  test('logReturn logs correct return message', () => { // (verify logReturn output)
+    spy = mockConsole('log'); // (replace console.log)
+    logReturn('fn', 'value'); // (trigger log)
+    const last = spy.mock.calls.length - 1; // (index of our log entry)
+    assert.strictEqual(spy.mock.calls[last][0], '[RETURN] fn -> "value"'); // (check output)
+  });
 });

--- a/test/mockConsole.test.js
+++ b/test/mockConsole.test.js
@@ -55,8 +55,12 @@ function verifyMockImplementation(){ //function tests mockImplementation overrid
  }
 } //end verifyMockImplementation
 
-if(verifySpyCaptures() && verifyMockImplementation()){ //run tests sequentially and evaluate results
- console.log('mockConsole tests passed'); //output success message
-}else{ //if either test fails
- console.error('mockConsole tests failed'); //output failure message
-}
+describe('mockConsole', () => { // (group mockConsole tests)
+  test('captures calls', () => { // (verify spy captures calls)
+    expect(verifySpyCaptures()).toBe(true); // (assert function result)
+  });
+
+  test('supports mockImplementation', () => { // (verify mockImplementation use)
+    expect(verifyMockImplementation()).toBe(true); // (assert function result)
+  });
+});


### PR DESCRIPTION
## Summary
- convert integration test to `describe` and `test`
- refactor log utils tests to use Jest
- refactor mockConsole tests to use Jest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843a4ac15e08322ac58fd3c95170b26