### PR TITLE
Refactor tests to use Jest structures

### DIFF
--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -20,7 +20,7 @@ async function searchTask(url){ // (test module performing http and logging)
   }
 }
 
-(async () => { // (self-running async test block)
+test('integration test using stubs', async () => { //wrap previous IIFE in jest test
   const mocks = initSearchTest(); // (setup env and create mocks)
   let axiosCalled = false; // (track axios usage)
   const restorePost = stubMethod(stubs.axios, 'post', async () => { // (stub axios.post)
@@ -36,12 +36,12 @@ async function searchTask(url){ // (test module performing http and logging)
 
   const logSpy = mockConsole('log'); // (capture console.log output)
   const result = await searchTask('https://example.com'); // (execute module)
-  assert.strictEqual(result, true); // (check result)
-  assert(axiosCalled); // (verify axios used)
-  assert(infoCalled); // (verify logger used)
+  expect(result).toBe(true); // (check result with jest expect)
+  expect(axiosCalled).toBe(true); // (verify axios used)
+  expect(infoCalled).toBe(true); // (verify logger used)
   logSpy.mockRestore(); // (restore console.log)
   restorePost(); // (restore axios.post)
   restoreLogger(); // (restore winston.createLogger)
   resetMocks(mocks.mock, mocks.scheduleMock, mocks.qerrorsMock); // (clean mocks)
   console.log('integration test complete'); // (final log)
-})();
+});

--- a/test/logUtils.test.js
+++ b/test/logUtils.test.js
@@ -1,32 +1,26 @@
 require('../setup'); //ensure stubs active
 
-const assert = require('assert'); //built-in assertion library
 const { logStart, logReturn } = require('../lib/logUtils'); //functions under test
 const { mockConsole } = require('../utils/mockConsole'); //capture console output
 
-function runTest(desc, testFn) {
-  try {
-    testFn();
-    console.log(`\u2713 ${desc}`); //success indicator
-  } catch (err) {
-    console.error(`\u2717 ${desc}`); //failure indicator
-    console.error(err);
-    process.exitCode = 1; //signal test failure
-  }
-}
+describe('logUtils', () => { //replace custom runTest with jest describe block
+  let spy; //store console spy for each test
 
-runTest('logStart logs correct start message', () => {
-  const spy = mockConsole('log'); //replace console.log
-  logStart('fn', 1, 2); //trigger log
-  const last = spy.mock.calls.length - 1; //index of our log entry
-  assert.strictEqual(spy.mock.calls[last][0], '[START] fn(1, 2)'); //check output
-  spy.mockRestore(); //restore console.log
-});
+  afterEach(() => { //ensure spy restoration after each test
+    if (spy) spy.mockRestore(); //restore console.log safely
+  });
 
-runTest('logReturn logs correct return message', () => {
-  const spy = mockConsole('log'); //replace console.log
-  logReturn('fn', 'value'); //trigger log
-  const last = spy.mock.calls.length - 1; //index of our log entry
-  assert.strictEqual(spy.mock.calls[last][0], '[RETURN] fn -> "value"'); //check output
-  spy.mockRestore(); //restore console.log
+  test('logStart logs correct start message', () => { //jest test block for logStart
+    spy = mockConsole('log'); //replace console.log
+    logStart('fn', 1, 2); //trigger log
+    const last = spy.mock.calls.length - 1; //index of our log entry
+    expect(spy.mock.calls[last][0]).toBe('[START] fn(1, 2)'); //assert with jest expect
+  });
+
+  test('logReturn logs correct return message', () => { //jest test block for logReturn
+    spy = mockConsole('log'); //replace console.log
+    logReturn('fn', 'value'); //trigger log
+    const last = spy.mock.calls.length - 1; //index of our log entry
+    expect(spy.mock.calls[last][0]).toBe('[RETURN] fn -> "value"'); //assert with jest expect
+  });
 });


### PR DESCRIPTION
## Summary
- refactor logUtils tests into Jest blocks
- replace manual mockConsole tests with `describe`/`test`
- wrap integration test in a proper Jest `test`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6843a4ded4908322af1837faafccec22