### PR TITLE
Fix axios mock reply storage

### DIFF
--- a/test/axiosMock.test.js
+++ b/test/axiosMock.test.js
@@ -1,0 +1,9 @@
+const { testEnv } = require('..'); //import utilities
+
+test('axios mock stores replies and resets', () => { //jest test verifying persistence
+  const mock = testEnv.createAxiosMock();
+  mock.onGet('/users').reply(200, { ok: true });
+  expect(mock.getReply('/users', 'get')).toEqual({ status: 200, data: { ok: true } });
+  mock.reset();
+  expect(mock.getReply('/users', 'get')).toBeUndefined();
+});

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -20,7 +20,7 @@ async function searchTask(url){ // (test module performing http and logging)
   }
 }
 
-(async () => { // (self-running async test block)
+test('integration scenario completes', async () => { //wrap IIFE in jest test
   const mocks = initSearchTest(); // (setup env and create mocks)
   let axiosCalled = false; // (track axios usage)
   const restorePost = stubMethod(stubs.axios, 'post', async () => { // (stub axios.post)
@@ -44,4 +44,4 @@ async function searchTask(url){ // (test module performing http and logging)
   restoreLogger(); // (restore winston.createLogger)
   resetMocks(mocks.mock, mocks.scheduleMock, mocks.qerrorsMock); // (clean mocks)
   console.log('integration test complete'); // (final log)
-})();
+});

--- a/test/logUtils.test.js
+++ b/test/logUtils.test.js
@@ -1,32 +1,21 @@
 require('../setup'); //ensure stubs active
 
-const assert = require('assert'); //built-in assertion library
+const assert = require('assert'); //built-in assertion library (kept for internal checks)
 const { logStart, logReturn } = require('../lib/logUtils'); //functions under test
 const { mockConsole } = require('../utils/mockConsole'); //capture console output
 
-function runTest(desc, testFn) {
-  try {
-    testFn();
-    console.log(`\u2713 ${desc}`); //success indicator
-  } catch (err) {
-    console.error(`\u2717 ${desc}`); //failure indicator
-    console.error(err);
-    process.exitCode = 1; //signal test failure
-  }
-}
-
-runTest('logStart logs correct start message', () => {
+test('logStart logs correct start message', () => { //wrap in jest test to satisfy jest
   const spy = mockConsole('log'); //replace console.log
   logStart('fn', 1, 2); //trigger log
   const last = spy.mock.calls.length - 1; //index of our log entry
-  assert.strictEqual(spy.mock.calls[last][0], '[START] fn(1, 2)'); //check output
+  expect(spy.mock.calls[last][0]).toBe('[START] fn(1, 2)'); //assert log output
   spy.mockRestore(); //restore console.log
 });
 
-runTest('logReturn logs correct return message', () => {
+test('logReturn logs correct return message', () => { //wrap second check in jest test
   const spy = mockConsole('log'); //replace console.log
   logReturn('fn', 'value'); //trigger log
   const last = spy.mock.calls.length - 1; //index of our log entry
-  assert.strictEqual(spy.mock.calls[last][0], '[RETURN] fn -> "value"'); //check output
+  expect(spy.mock.calls[last][0]).toBe('[RETURN] fn -> "value"'); //assert log output
   spy.mockRestore(); //restore console.log
 });

--- a/test/mockConsole.test.js
+++ b/test/mockConsole.test.js
@@ -55,8 +55,10 @@ function verifyMockImplementation(){ //function tests mockImplementation overrid
  }
 } //end verifyMockImplementation
 
-if(verifySpyCaptures() && verifyMockImplementation()){ //run tests sequentially and evaluate results
- console.log('mockConsole tests passed'); //output success message
-}else{ //if either test fails
- console.error('mockConsole tests failed'); //output failure message
-}
+test('mockConsole captures calls', () => { //jest test verifying capture utility
+  expect(verifySpyCaptures()).toBe(true); //expect helper to indicate success
+});
+
+test('mockImplementation override works', () => { //jest test verifying implementation override
+  expect(verifyMockImplementation()).toBe(true); //expect helper to indicate success
+});

--- a/utils/testEnv.js
+++ b/utils/testEnv.js
@@ -227,51 +227,61 @@ function createQerrorsMock() {
  */
 function createAxiosMock() {
   logStart('createAxiosMock', 'none');
-  
+
   // Simple axios mock adapter without external dependencies
   // Stores configured replies for different URLs and methods
   const mock = {
+    _replies: { get: {}, post: {} }, //track replies per method on outer object
+
     /**
      * Configure mock response for GET requests to a specific URL
      * @param {string} url - URL to mock
      * @returns {Object} Reply configuration object
      */
     onGet: function(url) {
+      const outer = this; //reference outer mock for storing replies
       return {
         reply: function(status, data) {
-          // Store reply configuration for this URL
-          this._replies = this._replies || {};
-          this._replies[url] = { status, data };
-          return this; // Allow method chaining
+          outer._replies.get[url] = { status, data }; //store reply on outer mock
+          return outer; //return outer mock for chaining
         }
       };
     },
-    
+
     /**
      * Configure mock response for POST requests to a specific URL
      * @param {string} url - URL to mock
      * @returns {Object} Reply configuration object
      */
     onPost: function(url) {
+      const outer = this; //reference outer mock for storing replies
       return {
         reply: function(status, data) {
-          // Store reply configuration for this URL
-          this._replies = this._replies || {};
-          this._replies[url] = { status, data };
-          return this; // Allow method chaining
+          outer._replies.post[url] = { status, data }; //store reply on outer mock
+          return outer; //return outer mock for chaining
         }
       };
     },
-    
+
+    /**
+     * Retrieve stored reply configuration for assertions
+     * @param {string} url - Request URL used when configuring reply
+     * @param {string} method - HTTP method ('get' or 'post')
+     * @returns {Object|undefined} Stored reply or undefined if none
+     */
+    getReply: function(url, method) {
+      return (this._replies[method] || {})[url]; //lookup reply in store
+    },
+
     /**
      * Reset all configured mocks
      * Essential for preventing test pollution
      */
     reset: function() {
-      this._replies = {}; // Clear all stored replies
+      this._replies = { get: {}, post: {} }; //clear reply storage
     }
   };
-  
+
   logReturn('createAxiosMock', 'adapter');
   return mock;
 }


### PR DESCRIPTION
## Summary
- store `onGet/onPost` replies on the outer axios mock object
- add `getReply` helper and reset storage on `reset`
- convert manual test files to Jest tests
- add tests to verify axios mock reply persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843b99e45608322a414523e35f160b0