### PR TITLE
Fix async demo for commonjs

### DIFF
--- a/example.js
+++ b/example.js
@@ -211,6 +211,8 @@ console.log('TEST_VARIABLE after restore:', process.env.TEST_VARIABLE || 'undefi
  */
 console.log('\n4. Mock Creation for Complex Dependencies:');
 
+(async () => { // (wrapping async demo to allow top-level await in CommonJS)
+
 // Create a scheduler mock for testing rate-limited operations
 // Real schedulers delay execution; this mock executes immediately
 const scheduleMock = testEnv.createScheduleMock();
@@ -296,6 +298,8 @@ testEnv.resetMocks(testMocks.mock, testMocks.scheduleMock, testMocks.qerrorsMock
 
 console.log('\n=== All Examples Complete ===');
 console.log('All mocks have been cleaned up and original behavior restored');
+
+})(); // (end async wrapper to keep CommonJS compatible)
 
 /**
  * Key Takeaways for Using qtests:


### PR DESCRIPTION
## Summary
- wrap example schedule and integration demos in an async IIFE so `await` works in CommonJS

## Testing
- `npm test` *(fails: Your test suite must contain at least one test)*
- `node example.js` *(fails: TypeError: Invalid URL)*

------
https://chatgpt.com/codex/tasks/task_b_6843b9a3c6748322b0a8d4388bb20380