### PR TITLE
Improve log serialization

### DIFF
--- a/lib/logUtils.js
+++ b/lib/logUtils.js
@@ -17,7 +17,33 @@
  * - Easy to disable by modifying this single file
  * - Helps users understand what qtests is doing during test setup
  * - Essential for debugging complex test environment issues
+*/
+
+// Import util for safe inspection fallback //(new dependency)
+const util = require('util'); //(require util module)
+
+/**
+ * Safely converts values to strings for logging
+ *
+ * Attempts JSON serialization first, then falls back to util.inspect.
+ * Returns '[unserializable]' if both methods fail.
+ *
+ * @param {any} value - Value to serialize for log output
+ * @returns {string} Serialized representation
  */
+function safeSerialize(value) {
+  try { //attempt JSON serialization //(try stringify first)
+    const serialized = JSON.stringify(value); //(primary stringify)
+    return serialized; //return JSON string without extra logs
+  } catch (error) { //handle JSON failure
+    try { //attempt util.inspect
+      const inspected = util.inspect(value, { depth: null }); //(inspect fallback)
+      return inspected; //return inspected string
+    } catch (innerErr) { //handle inspect failure
+      return '[unserializable]'; //fallback placeholder
+    }
+  }
+}
 
 /**
  * Logs function entry with arguments
@@ -28,12 +54,12 @@
  * 
  * Technical implementation:
  * - Uses console.log for immediate output (no buffering)
- * - JSON.stringify handles objects, arrays, and primitive values safely
+ * - safeSerialize handles objects, arrays, and primitive values safely //(update comment)
  * - Spread operator accepts variable number of arguments
  * - [START] prefix makes entry points easy to identify in logs
  * 
  * Argument serialization approach:
- * - JSON.stringify converts any value to readable string
+ * - safeSerialize converts any value to readable string //(update comment)
  * - Handles undefined, null, objects, arrays consistently
  * - Truncates long values naturally (JSON has reasonable limits)
  * - Avoids issues with toString() on complex objects
@@ -42,9 +68,9 @@
  * @param {...any} args - All arguments passed to the function
  */
 function logStart(functionName, ...args) {
-  // Create readable representation of all arguments
-  // JSON.stringify handles edge cases like undefined, circular refs, etc.
-  const argsString = args.map(arg => JSON.stringify(arg)).join(', ');
+  // Create readable representation of all arguments //(ensure consistent output)
+  // safeSerialize handles JSON errors gracefully //(new helper usage)
+  const argsString = args.map(arg => safeSerialize(arg)).join(', '); //(changed serializer)
   
   // Log with consistent format: [START] functionName(arg1, arg2, ...)
   // This format is easy to parse and grep for debugging
@@ -65,7 +91,7 @@ function logStart(functionName, ...args) {
  * - Matches with START logs to show complete function execution
  * 
  * Return value serialization:
- * - Same JSON.stringify approach as logStart for consistency
+ * - Same safeSerialize approach as logStart for consistency //(update comment)
  * - Shows actual return values for verification
  * - Handles complex objects and primitives uniformly
  * 
@@ -73,9 +99,9 @@ function logStart(functionName, ...args) {
  * @param {any} returnValue - The value being returned by the function
  */
 function logReturn(functionName, returnValue) {
-  // Serialize return value using same approach as arguments
-  // This ensures consistent formatting between START and RETURN logs
-  const valueString = JSON.stringify(returnValue);
+  // Serialize return value using same approach as arguments //(keep consistent)
+  // safeSerialize prevents crashes on circular values //(new helper usage)
+  const valueString = safeSerialize(returnValue); //(changed serializer)
   
   // Log with consistent format: [RETURN] functionName -> returnValue
   // Arrow notation clearly indicates this is a return value


### PR DESCRIPTION
## Summary
- serialize logs with new `safeSerialize` helper using JSON and util.inspect fallbacks
- use `safeSerialize` in `logStart` and `logReturn`
- update docs in `logUtils.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843cf5792488322bc097635c62d2011