### PR TITLE
defer stub activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,13 @@ restore();
 
 ### 2. Stubbing Modules for All Tests
 
-Before running your tests, use the setup script to tell Node.js to look in your stubs directory first when resolving modules. This way, any code that imports `axios` or `winston` will get your test doubles automatically.
+Before running your tests, call the setup helper so Node.js loads the stubs directory first. Until this is done, modules like `axios` or `winston` will resolve to their real implementations.
 
 **In your test runner setup (e.g., Mocha’s `--require` or Jest’s setup):**
 
 ```js
+require('qtests').setup();
+// or
 require('qtests/setup');
 ```
 
@@ -112,7 +114,7 @@ module.exports = async function myFunction() {
 **Test:**
 
 ```js
-require('qtests/setup'); // Must be called before requiring your module
+require('qtests').setup(); // Must be called before requiring your module
 
 const myFunction = require('./myFunction'); // Will use stubbed axios and winston
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,17 @@ const stubMethod = require('./utils/stubMethod');
 const { mockConsole } = require('./utils/mockConsole');
 const testEnv = require('./utils/testEnv');
 
+function setup(){ // (function exported so stubs activate only when called)
+  console.log(`setup is running with none`); // (debug start log)
+  try{ // (error handling wrapper)
+    require('./setup'); // (load setup side effect on demand)
+    console.log(`setup is returning undefined`); // (debug return log)
+  }catch(error){ // (catch any require failure)
+    console.log(`setup encountered ${error.message}`); // (error log)
+    throw error; // (propagate error)
+  }
+} // (end setup function)
+
 /**
  * Main module exports
  * 
@@ -36,8 +47,8 @@ module.exports = {
   testEnv,         // Environment and mock management for complex test scenarios
   
   // Setup utility - separated because it modifies global Node.js module resolution
-  // Users must explicitly require this to enable automatic stub resolution
-  setup: require('./setup'),
+  // Users must explicitly invoke this function to enable stub resolution
+  setup, // (call this to activate stubs when desired)
   
   // Stub library - organized under namespace to group related mock implementations
   // This prevents naming conflicts and makes it clear these are replacement modules

--- a/test/indexExports.test.js
+++ b/test/indexExports.test.js
@@ -1,4 +1,4 @@
-require('../setup'); // (enable stub path before importing index)
+require('..').setup(); // (activate stubs before importing index)
 
 const index = require('..'); // (load main exports)
 const directStubMethod = require('../utils/stubMethod'); // (direct stubMethod for comparison)
@@ -9,7 +9,7 @@ const { mockConsole: directMockConsole } = require('../utils/mockConsole'); // (
   expect(typeof index.stubMethod).toBe('function'); // (stubMethod export must be a function)
   expect(typeof index.mockConsole).toBe('function'); // (mockConsole export must be a function)
   expect(typeof index.testEnv).toBe('object'); // (testEnv export should be an object)
-  expect(typeof index.setup).toBe('object'); // (setup export is the setup side-effect module)
+  expect(typeof index.setup).toBe('function'); // (setup export is a callable helper)
   expect(typeof index.stubs).toBe('object'); // (stubs namespace object)
   expect(typeof index.stubs.axios).toBe('object'); // (axios stub object)
   expect(typeof index.stubs.winston).toBe('object'); // (winston stub object)

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,4 +1,4 @@
-require('../setup'); //initialize stub resolution before requiring modules
+require('..').setup(); //initialize stub resolution before requiring modules
 
 const { stubMethod, mockConsole, testEnv, stubs } = require('..'); //import qtests utilities
 const { initSearchTest, resetMocks } = testEnv; //extract env helpers

--- a/test/logUtils.test.js
+++ b/test/logUtils.test.js
@@ -1,4 +1,4 @@
-require('../setup'); //ensure stubs active
+require('..').setup(); //ensure stubs active
 
 const { logStart, logReturn } = require('../lib/logUtils'); //functions under test
 const { mockConsole } = require('../utils/mockConsole'); //capture console output

--- a/test/mockConsole.test.js
+++ b/test/mockConsole.test.js
@@ -1,4 +1,4 @@
-require('../setup'); //load qtests setup for stub resolution
+require('..').setup(); //load qtests setup for stub resolution
 
 const { mockConsole } = require('../utils/mockConsole'); //import mockConsole utility for testing
 

--- a/test/setupResolution.test.js
+++ b/test/setupResolution.test.js
@@ -1,4 +1,4 @@
-require('../setup'); //(activate stubs for subsequent requires)
+require('..').setup(); //(activate stubs for subsequent requires)
 
 const { execFileSync } = require('child_process'); //(utility to run child scripts)
 const path = require('path'); //(resolve helper script path)

--- a/test/stubMethod.test.js
+++ b/test/stubMethod.test.js
@@ -1,4 +1,4 @@
-require('qtests/setup'); // (activate stubs before imports)
+require('..').setup(); // (activate stubs before imports)
 const stubMethod = require('../utils/stubMethod'); // (import module under test)
 
 test('stubMethod replaces and restores methods', () => { // (jest test case)

--- a/test/testEnv.test.js
+++ b/test/testEnv.test.js
@@ -1,4 +1,4 @@
-require('qtests/setup'); // (initialize stubs before imports)
+require('..').setup(); // (initialize stubs before imports)
 
 const { setTestEnv, saveEnv, restoreEnv, createScheduleMock, createQerrorsMock, createAxiosMock, resetMocks, initSearchTest } = require('../utils/testEnv'); // (import utilities under test)
 


### PR DESCRIPTION
## Summary
- add a callable `setup` helper in `index.js`
- adjust README to call `qtests.setup()`
- update tests to invoke the new setup helper

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6843cf6b11148322a80e78698b6fe49e