### PR TITLE
Add reply store on axios mock

### DIFF
--- a/test/testEnv.test.js
+++ b/test/testEnv.test.js
@@ -45,17 +45,17 @@ test('createQerrorsMock captures arguments', () => { // (verify error mock)
 
 test('createAxiosMock stores replies and resets', () => { // (verify axios mock)
   const axiosMock = createAxiosMock(); // (create axios adapter)
-  const cfg = axiosMock.onGet('/test').reply(200, { ok: true }); // (configure get reply)
-  expect(cfg._replies['/test']).toEqual({ status: 200, data: { ok: true } }); // (replies stored)
+  axiosMock.onGet('/test').reply(200, { ok: true }); // (configure get reply)
+  expect(axiosMock._replies['/test']).toEqual({ status: 200, data: { ok: true } }); // (reply stored on adapter)
   axiosMock.reset(); // (reset replies on adapter)
-  const cfg2 = axiosMock.onGet('/again').reply(200, { ok: false }); // (configure after reset)
-  expect(cfg2._replies).toEqual({ '/again': { status: 200, data: { ok: false } } }); // (old replies cleared)
+  axiosMock.onGet('/again').reply(200, { ok: false }); // (configure after reset)
+  expect(axiosMock._replies).toEqual({ '/again': { status: 200, data: { ok: false } } }); // (old replies cleared)
 });
 
 test('createAxiosMock stores post replies', () => { // (verify axios post mock)
   const axiosMock = createAxiosMock(); // (create adapter for post)
-  const cfg = axiosMock.onPost('/url').reply(200, { foo: 'bar' }); // (configure post reply)
-  expect(cfg._replies['/url']).toEqual({ status: 200, data: { foo: 'bar' } }); // (post reply stored)
+  axiosMock.onPost('/url').reply(200, { foo: 'bar' }); // (configure post reply)
+  expect(axiosMock._replies['/url']).toEqual({ status: 200, data: { foo: 'bar' } }); // (post reply stored)
 });
 
 

--- a/utils/testEnv.js
+++ b/utils/testEnv.js
@@ -239,10 +239,8 @@ function createAxiosMock() {
     onGet: function(url) {
       return {
         reply: function(status, data) {
-          // Store reply configuration for this URL
-          this._replies = this._replies || {};
-          this._replies[url] = { status, data };
-          return this; // Allow method chaining
+          mock._replies[url] = { status, data }; // (store get response on adapter)
+          return mock; // (return adapter for chaining)
         }
       };
     },
@@ -255,10 +253,8 @@ function createAxiosMock() {
     onPost: function(url) {
       return {
         reply: function(status, data) {
-          // Store reply configuration for this URL
-          this._replies = this._replies || {};
-          this._replies[url] = { status, data };
-          return this; // Allow method chaining
+          mock._replies[url] = { status, data }; // (store post response on adapter)
+          return mock; // (return adapter for chaining)
         }
       };
     },
@@ -268,9 +264,11 @@ function createAxiosMock() {
      * Essential for preventing test pollution
      */
     reset: function() {
-      this._replies = {}; // Clear all stored replies
+      mock._replies = {}; // (clear stored replies on adapter)
     }
   };
+
+  mock._replies = {}; // (initialize reply store for adapter)
   
   logReturn('createAxiosMock', 'adapter');
   return mock;


### PR DESCRIPTION
## Summary
- init axios mock with `_replies`
- store replies on adapter for `onGet` and `onPost`
- clear replies on reset
- update axios mock tests to check adapter replies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6843d850fd108322ba88bf6fa4327b1b