### PR TITLE
Improve mockConsole call tracking

### DIFF
--- a/test/mockConsole.test.js
+++ b/test/mockConsole.test.js
@@ -25,7 +25,27 @@ test('mockConsole mockImplementation works', () => { //jest test verifying mockI
   spy.mockImplementation(msg => customOut.push(msg)); //override console.log
   console.log('override'); //call overridden console method
   expect(customOut).toEqual(['override']); //custom function captured call
-  expect(spy.mock.calls.length).toBe(1); //creation log only
+  expect(spy.mock.calls.length).toBe(2); //tracks override call as well
+  expect(spy.mock.calls[1][0]).toBe('override'); //second call stores argument
+  spy.mockRestore(); //restore console.log via spy
+  console.log = realLog; //restore original console.log
+});
+
+test('mockConsole tracks calls after reimplementation', () => { //verify multiple overrides
+  const firstOut = []; //array for first implementation
+  const secondOut = []; //array for second implementation
+  const realLog = console.log; //save original console.log
+  console.log = () => {}; //silence console during test
+  const spy = mockConsole('log'); //create console spy for log method
+  spy.mockImplementation(msg => firstOut.push(msg)); //first custom behavior
+  console.log('one'); //call with first implementation
+  spy.mockImplementation(msg => secondOut.push(msg)); //second custom behavior
+  console.log('two'); //call with second implementation
+  expect(firstOut).toEqual(['one']); //first custom function captured call
+  expect(secondOut).toEqual(['two']); //second custom function captured call
+  expect(spy.mock.calls.length).toBe(3); //tracks creation and both calls
+  expect(spy.mock.calls[1][0]).toBe('one'); //first tracked arg correct
+  expect(spy.mock.calls[2][0]).toBe('two'); //second tracked arg correct
   spy.mockRestore(); //restore console.log via spy
   console.log = realLog; //restore original console.log
 });


### PR DESCRIPTION
## Summary
- keep track of custom console implementations
- ensure wrapper logs every call when mockImplementation is used
- test that wrapped console continues to track calls

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6843d857b4c88322b717590c8ea90280