### PR TITLE
Add executeWithLogs utility

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,16 +17,10 @@
 const stubMethod = require('./utils/stubMethod');
 const { mockConsole } = require('./utils/mockConsole');
 const testEnv = require('./utils/testEnv');
+const { executeWithLogs } = require('./lib/logUtils'); //(import executeWithLogs)
 
 function setup(){ // (function exported so stubs activate only when called)
-  console.log(`setup is running with none`); // (debug start log)
-  try{ // (error handling wrapper)
-    require('./setup'); // (load setup side effect on demand)
-    console.log(`setup is returning undefined`); // (debug return log)
-  }catch(error){ // (catch any require failure)
-    console.log(`setup encountered ${error.message}`); // (error log)
-    throw error; // (propagate error)
-  }
+  return executeWithLogs('setup', () => require('./setup')); //(delegate to executeWithLogs)
 } // (end setup function)
 
 /**

--- a/lib/logUtils.js
+++ b/lib/logUtils.js
@@ -110,4 +110,38 @@ function logReturn(functionName, returnValue) {
 
 // Export both functions for use throughout the qtests module
 // These provide the foundation for all function call tracing
-module.exports = { logStart, logReturn };
+/**
+ * Executes a callback with standardized logging
+ *
+ * Outputs `${name} is running with` before execution, `${name} is returning`
+ * when the callback succeeds, and `${name} encountered` if it throws. Works
+ * with synchronous or asynchronous callbacks.
+ *
+ * @param {string} name - Identifier used in log messages
+ * @param {Function} fn - Callback to execute
+ * @param {...any} args - Arguments to pass to the callback
+ * @returns {any|Promise} Result of the callback
+ */
+function executeWithLogs(name, fn, ...args) {
+  const argString = args.length ? args.map(a => safeSerialize(a)).join(', ') : 'none'; //(serialize arguments)
+  console.log(`${name} is running with ${argString}`); //(start log)
+  try{ // (wrap callback execution)
+    const result = fn(...args); //(invoke callback)
+    if (result && typeof result.then === 'function') { // (handle promise result)
+      return result.then(res => { // (await async resolution)
+        console.log(`${name} is returning ${safeSerialize(res)}`); //(async return log)
+        return res; //(forward async result)
+      }).catch(err => { // (async error path)
+        console.log(`${name} encountered ${err.message}`); //(async error log)
+        throw err; //(rethrow async error)
+      });
+    }
+    console.log(`${name} is returning ${safeSerialize(result)}`); //(sync return log)
+    return result; //(return sync result)
+  }catch(error){ // (sync error path)
+    console.log(`${name} encountered ${error.message}`); //(sync error log)
+    throw error; //(rethrow sync error)
+  }
+}
+
+module.exports = { logStart, logReturn, executeWithLogs }; //(export new helper)

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -2,21 +2,17 @@ require('..').setup(); //initialize stub resolution before requiring modules
 
 const { stubMethod, mockConsole, testEnv, stubs } = require('..'); //import qtests utilities
 const { initSearchTest, resetMocks } = testEnv; //extract env helpers
+const { executeWithLogs } = require('../lib/logUtils'); //(import executeWithLogs)
 
 async function searchTask(url){ //test module performing http and logging
-  console.log(`searchTask is running with ${url}`); //debug start log
-  try{ //attempt api call
+  return executeWithLogs('searchTask', async target => { //(delegate to executeWithLogs)
     const axios = stubs.axios; //directly use axios stub
     const winston = stubs.winston; //directly use winston stub
     const logger = winston.createLogger(); //create stubbed logger
-    await axios.post(url, {}); //perform HTTP request
+    await axios.post(target, {}); //perform HTTP request
     logger.info('request finished'); //log completion
-    console.log(`searchTask is returning true`); //debug return log
     return true; //return result
-  }catch(error){ //handle error
-    console.log(`searchTask encountered ${error.message}`); //error log
-    throw error; //rethrow failure
-  }
+  }, url);
 }
 
 test('integration flow using stubs', async () => { //jest test executing searchTask

--- a/test/logUtils.test.js
+++ b/test/logUtils.test.js
@@ -1,6 +1,6 @@
 require('..').setup(); //ensure stubs active
 
-const { logStart, logReturn } = require('../lib/logUtils'); //functions under test
+const { logStart, logReturn, executeWithLogs } = require('../lib/logUtils'); //functions under test
 const { mockConsole } = require('../utils/mockConsole'); //capture console output
 
 test('logStart logs correct start message', () => { //jest test for logStart
@@ -16,6 +16,32 @@ test('logReturn logs correct return message', () => { //jest test for logReturn
   logReturn('fn', 'value'); //trigger log
   const last = spy.mock.calls.length - 1; //index of log entry
   expect(spy.mock.calls[last][0]).toBe('[RETURN] fn -> "value"'); //check output
+  spy.mockRestore(); //restore console.log
+});
+
+test('executeWithLogs wraps sync function', () => { //jest test for executeWithLogs sync
+  const spy = mockConsole('log'); //replace console.log
+  function add(a, b){ //simple addition
+    return a + b; //return sum
+  }
+  const res = executeWithLogs('add', add, 1, 2); //execute with logging
+  expect(res).toBe(3); //verify result
+  expect(spy.mock.calls[1][0]).toBe('add is running with 1, 2'); //check start log
+  const last = spy.mock.calls.length - 1; //index of last log
+  expect(spy.mock.calls[last][0]).toBe('add is returning 3'); //check return log
+  spy.mockRestore(); //restore console.log
+});
+
+test('executeWithLogs wraps async function', async () => { //jest test for executeWithLogs async
+  const spy = mockConsole('log'); //replace console.log
+  async function fetchVal(){ //dummy async
+    return 'ok'; //return value
+  }
+  const res = await executeWithLogs('fetchVal', fetchVal); //execute with logging
+  expect(res).toBe('ok'); //verify result
+  expect(spy.mock.calls[1][0]).toBe('fetchVal is running with none'); //check start log
+  const last = spy.mock.calls.length - 1; //index of last log
+  expect(spy.mock.calls[last][0]).toBe('fetchVal is returning "ok"'); //check return log
   spy.mockRestore(); //restore console.log
 });
 

--- a/test/setupResolution.test.js
+++ b/test/setupResolution.test.js
@@ -2,30 +2,24 @@ require('..').setup(); //(activate stubs for subsequent requires)
 
 const { execFileSync } = require('child_process'); //(utility to run child scripts)
 const path = require('path'); //(resolve helper script path)
+const { executeWithLogs } = require('../lib/logUtils'); //(import executeWithLogs)
 
 function runChild(includeSetup){ //(execute child script with or without setup)
- console.log(`runChild is running with ${includeSetup}`); //(start log)
- try{ //(attempt execution)
+ return executeWithLogs('runChild', () => { //(delegate to executeWithLogs)
   const script = path.join(__dirname, 'withoutSetup.js'); //(child script path)
   const args = includeSetup ? ['-r', path.join(__dirname, '../setup'), script] : [script]; //(create arg list)
   const out = execFileSync(process.execPath, args, { env: { NODE_PATH: '' } }).toString(); //(spawn child)
   const res = JSON.parse(out); //(parse child output)
-  console.log(`runChild is returning ${JSON.stringify(res)}`); //(return log)
   return res; //(forward result)
- }catch(error){ //(handle errors)
-  console.error(error); //(output problem)
-  return {}; //(fallback result)
- }
+ }, includeSetup);
 } //(end runChild)
 
 function runWithoutSetup(){ //(spawn child process without setup)
- console.log(`runWithoutSetup is running with none`); //(start log)
- return runChild(false); //(delegate to runChild)
+ return executeWithLogs('runWithoutSetup', () => runChild(false)); //(delegate to executeWithLogs)
 } //(end runWithoutSetup)
 
 function runWithSetup(){ //(spawn child process with setup)
- console.log(`runWithSetup is running with none`); //(start log)
- return runChild(true); //(delegate to runChild)
+ return executeWithLogs('runWithSetup', () => runChild(true)); //(delegate to executeWithLogs)
 } //(end runWithSetup)
 
 test('child process uses stubs when setup is required', () => { //(jest test case)


### PR DESCRIPTION
## Summary
- add `executeWithLogs` to logUtils
- refactor setup function and tests helpers to use `executeWithLogs`
- add coverage for the new utility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68449618e3cc8322a4e2c583d1a196f7