### PR TITLE
Add withMockConsole helper

### DIFF
--- a/test/indexExports.test.js
+++ b/test/indexExports.test.js
@@ -3,6 +3,7 @@ require('..').setup(); // (activate stubs before importing index)
 const index = require('..'); // (load main exports)
 const directStubMethod = require('../utils/stubMethod'); // (direct stubMethod for comparison)
 const { mockConsole: directMockConsole } = require('../utils/mockConsole'); // (direct mockConsole for comparison)
+const { withMockConsole } = require('../utils/testHelpers'); //(helper for console spies)
 
 // Jest-style test verifying export presence
  test('index exports expected modules', () => {
@@ -27,12 +28,10 @@ const { mockConsole: directMockConsole } = require('../utils/mockConsole'); // (
 });
 
 // Verify mockConsole behaves same via index
- test('mockConsole via index works like direct import', () => {
-  const spy = index.mockConsole('log'); // (create spy via index)
+test('mockConsole via index works like direct import', () => withMockConsole('log', spy => { //(use helper for spy lifecycle)
   console.log('test'); // (emit log to be captured)
-  spy.mockRestore(); // (restore console)
   expect(spy.mock.calls.length).toBe(2); // (expect creation log and test log)
   expect(spy.mock.calls[1][0]).toBe('test'); // (verify captured argument)
   expect(index.mockConsole).toBe(directMockConsole); // (same function reference)
-});
+}));
 

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,7 +1,8 @@
 require('..').setup(); //initialize stub resolution before requiring modules
 
-const { stubMethod, mockConsole, testEnv, stubs } = require('..'); //import qtests utilities
+const { stubMethod, testEnv, stubs } = require('..'); //import qtests utilities minus mockConsole
 const { initSearchTest, resetMocks } = testEnv; //extract env helpers
+const { withMockConsole } = require('../utils/testHelpers'); //(helper for console spies)
 
 async function searchTask(url){ //test module performing http and logging
   console.log(`searchTask is running with ${url}`); //debug start log
@@ -19,7 +20,7 @@ async function searchTask(url){ //test module performing http and logging
   }
 }
 
-test('integration flow using stubs', async () => { //jest test executing searchTask
+test('integration flow using stubs', () => withMockConsole('log', async logSpy => { //jest test executing searchTask with helper
   const mocks = initSearchTest(); //setup env and create mocks
   let axiosCalled = false; //track axios usage
   const restorePost = stubMethod(stubs.axios, 'post', async () => { //stub axios.post
@@ -33,14 +34,12 @@ test('integration flow using stubs', async () => { //jest test executing searchT
     }
   }));
 
-  const logSpy = mockConsole('log'); //capture console.log output
   const result = await searchTask('https://example.com'); //execute module
   expect(result).toBe(true); //check result
   expect(axiosCalled).toBe(true); //verify axios used
   expect(infoCalled).toBe(true); //verify logger used
-  logSpy.mockRestore(); //restore console.log
   restorePost(); //restore axios.post
   restoreLogger(); //restore winston.createLogger
   resetMocks(mocks.mock, mocks.scheduleMock, mocks.qerrorsMock); //clean mocks
-});
+}));
 

--- a/test/logUtils.test.js
+++ b/test/logUtils.test.js
@@ -1,21 +1,17 @@
 require('..').setup(); //ensure stubs active
 
 const { logStart, logReturn } = require('../lib/logUtils'); //functions under test
-const { mockConsole } = require('../utils/mockConsole'); //capture console output
+const { withMockConsole } = require('../utils/testHelpers'); //(helper for console spies)
 
-test('logStart logs correct start message', () => { //jest test for logStart
-  const spy = mockConsole('log'); //replace console.log
+test('logStart logs correct start message', () => withMockConsole('log', spy => { //jest test for logStart with helper
   logStart('fn', 1, 2); //trigger log
   const last = spy.mock.calls.length - 1; //index of log entry
   expect(spy.mock.calls[last][0]).toBe('[START] fn(1, 2)'); //check output
-  spy.mockRestore(); //restore console.log
-});
+}));
 
-test('logReturn logs correct return message', () => { //jest test for logReturn
-  const spy = mockConsole('log'); //replace console.log
+test('logReturn logs correct return message', () => withMockConsole('log', spy => { //jest test for logReturn with helper
   logReturn('fn', 'value'); //trigger log
   const last = spy.mock.calls.length - 1; //index of log entry
   expect(spy.mock.calls[last][0]).toBe('[RETURN] fn -> "value"'); //check output
-  spy.mockRestore(); //restore console.log
-});
+}));
 

--- a/utils/testHelpers.js
+++ b/utils/testHelpers.js
@@ -1,0 +1,18 @@
+const { mockConsole } = require('./mockConsole'); //(import console spy util)
+
+async function withMockConsole(method, fn){ //(run callback with console spy)
+  console.log(`withMockConsole is running with ${method}`); //(debug start log)
+  const spy = mockConsole(method); //(create console spy)
+  try{ //(run callback safely)
+    const res = await fn(spy); //(execute callback with spy)
+    console.log(`withMockConsole is returning ${res}`); //(debug return log)
+    return res; //(forward result)
+  }catch(err){ //(handle callback error)
+    console.log(`withMockConsole encountered ${err}`); //(log error)
+    throw err; //(rethrow for test failure)
+  }finally{ //(cleanup regardless of outcome)
+    spy.mockRestore(); //(restore original console method)
+  }
+} //(end helper)
+
+module.exports = { withMockConsole }; //(export helper)


### PR DESCRIPTION
## Summary
- add `withMockConsole` utility to wrap `mockConsole` setup/teardown
- use `withMockConsole` in existing tests to remove duplicate spy management

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844961e9e448322a30264bded6da49c