### PR TITLE
Configure global test setup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  setupFiles: ['<rootDir>/setup.js'], // (load qtests setup before tests)
+  setupFiles: ['<rootDir>/test/testSetup.js'], // (invoke exported setup for jest)
 };

--- a/test/indexExports.test.js
+++ b/test/indexExports.test.js
@@ -1,4 +1,3 @@
-require('..').setup(); // (activate stubs before importing index)
 
 const index = require('..'); // (load main exports)
 const directStubMethod = require('../utils/stubMethod'); // (direct stubMethod for comparison)

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,4 +1,3 @@
-require('..').setup(); //initialize stub resolution before requiring modules
 
 const { stubMethod, mockConsole, testEnv, stubs } = require('..'); //import qtests utilities
 const { initSearchTest, resetMocks } = testEnv; //extract env helpers

--- a/test/logUtils.test.js
+++ b/test/logUtils.test.js
@@ -1,4 +1,3 @@
-require('..').setup(); //ensure stubs active
 
 const { logStart, logReturn } = require('../lib/logUtils'); //functions under test
 const { mockConsole } = require('../utils/mockConsole'); //capture console output

--- a/test/mockConsole.test.js
+++ b/test/mockConsole.test.js
@@ -1,4 +1,3 @@
-require('..').setup(); //load qtests setup for stub resolution
 
 const { mockConsole } = require('../utils/mockConsole'); //import mockConsole utility for testing
 

--- a/test/setupResolution.test.js
+++ b/test/setupResolution.test.js
@@ -1,4 +1,3 @@
-require('..').setup(); //(activate stubs for subsequent requires)
 
 const { execFileSync } = require('child_process'); //(utility to run child scripts)
 const path = require('path'); //(resolve helper script path)

--- a/test/stubMethod.test.js
+++ b/test/stubMethod.test.js
@@ -1,4 +1,3 @@
-require('..').setup(); // (activate stubs before imports)
 const stubMethod = require('../utils/stubMethod'); // (import module under test)
 
 test('stubMethod replaces and restores methods', () => { // (jest test case)

--- a/test/testEnv.test.js
+++ b/test/testEnv.test.js
@@ -1,4 +1,3 @@
-require('..').setup(); // (initialize stubs before imports)
 
 const { setTestEnv, saveEnv, restoreEnv, createScheduleMock, createQerrorsMock, createAxiosMock, resetMocks, initSearchTest } = require('../utils/testEnv'); // (import utilities under test)
 

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -1,0 +1,1 @@
+require('..').setup(); // (activate stub resolution for jest)


### PR DESCRIPTION
## Summary
- create `testSetup.js` to activate `qtests` stubs for tests
- point Jest to new setup file
- remove duplicate setup calls from individual tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6844962252b08322a047f17d0cab20e3