### PR TITLE
Add default env defaults for tests

### DIFF
--- a/test/testEnv.test.js
+++ b/test/testEnv.test.js
@@ -1,5 +1,5 @@
 
-const { setTestEnv, saveEnv, restoreEnv, createScheduleMock, createQerrorsMock, createAxiosMock, resetMocks, initSearchTest } = require('../utils/testEnv'); // (import utilities under test)
+const { setTestEnv, saveEnv, restoreEnv, createScheduleMock, createQerrorsMock, createAxiosMock, resetMocks, initSearchTest, defaultEnv } = require('../utils/testEnv'); // (import utilities under test including defaults)
 
 test('setTestEnv sets variables', () => { // (verify environment variable setup)
   const saved = saveEnv(); // (store current environment)
@@ -7,9 +7,9 @@ test('setTestEnv sets variables', () => { // (verify environment variable setup)
   delete process.env.GOOGLE_CX; // (remove old cx)
   delete process.env.OPENAI_TOKEN; // (remove old token)
   setTestEnv(); // (apply standard test env)
-  expect(process.env.GOOGLE_API_KEY).toBe('key'); // (check key value)
-  expect(process.env.GOOGLE_CX).toBe('cx'); // (check cx value)
-  expect(process.env.OPENAI_TOKEN).toBe('token'); // (check token value)
+  expect(process.env.GOOGLE_API_KEY).toBe(defaultEnv.GOOGLE_API_KEY); // (check key value)
+  expect(process.env.GOOGLE_CX).toBe(defaultEnv.GOOGLE_CX); // (check cx value)
+  expect(process.env.OPENAI_TOKEN).toBe(defaultEnv.OPENAI_TOKEN); // (check token value)
   restoreEnv(saved); // (restore original env)
 });
 
@@ -78,7 +78,7 @@ test('resetMocks clears history on mocks', () => { // (verify centralized reset)
 test('initSearchTest sets env and returns mocks', () => { // (verify full init)
   const saved = saveEnv(); // (save environment state)
   const { mock, scheduleMock, qerrorsMock } = initSearchTest(); // (initialize search test)
-  expect(process.env.GOOGLE_API_KEY).toBe('key'); // (env key set)
+  expect(process.env.GOOGLE_API_KEY).toBe(defaultEnv.GOOGLE_API_KEY); // (env key set)
   expect(mock).toBeDefined(); // (axios mock present)
   expect(scheduleMock).toBeDefined(); // (schedule mock present)
   expect(qerrorsMock).toBeDefined(); // (qerrors mock present)

--- a/utils/testEnv.js
+++ b/utils/testEnv.js
@@ -22,6 +22,12 @@
 // Import logging utilities including wrapper for consistent logs
 const { logStart, logReturn, executeWithLogs } = require('../lib/logUtils'); //(add executeWithLogs and retain existing helpers)
 
+const defaultEnv = { // (shared env defaults for tests)
+  GOOGLE_API_KEY: 'key', // (fake google api key)
+  GOOGLE_CX: 'cx', // (fake search cx)
+  OPENAI_TOKEN: 'token' // (fake openai token)
+};
+
 /**
  * Sets up a standard test environment with common API keys
  * 
@@ -43,9 +49,7 @@ const { logStart, logReturn, executeWithLogs } = require('../lib/logUtils'); //(
  */
 function setTestEnv() {
   return executeWithLogs('setTestEnv', () => { //(log wrapper around env setup)
-    process.env.GOOGLE_API_KEY = 'key';   // Minimal fake API key
-    process.env.GOOGLE_CX = 'cx';         // Minimal fake Custom Search Engine ID
-    process.env.OPENAI_TOKEN = 'token';   // Minimal fake OpenAI token
+    Object.assign(process.env, defaultEnv); // (apply defaults)
     return true; //(report success)
   }, 'default values'); //(log parameter context)
 }
@@ -323,6 +327,7 @@ function initSearchTest() {
 // Each function serves a specific purpose and can be used independently
 // or in combination for complex test scenarios
 module.exports = {
+  defaultEnv,           // Export default env values
   setTestEnv,           // Set standard test environment variables
   saveEnv,              // Capture current environment for restoration
   restoreEnv,           // Restore previously saved environment


### PR DESCRIPTION
## Summary
- centralize default test environment values
- use Object.assign for setting environment
- export `defaultEnv`
- use `defaultEnv` in env tests

## Testing
- `npm test -- --silent`

------
https://chatgpt.com/codex/tasks/task_b_6844a5fa60a4832286f811a16b3c961b