### PR TITLE
Refactor tests with withMockConsole

### DIFF
--- a/test/logUtils.test.js
+++ b/test/logUtils.test.js
@@ -5,8 +5,6 @@ const { withMockConsole } = require('../utils/testHelpers'); //(helper for conso
 
 const { logStart, logReturn, executeWithLogs } = require('../lib/logUtils'); //functions under test, includes executeWithLogs
 
-const { mockConsole } = require('../utils/mockConsole'); //capture console output
-
 
 test('logStart logs correct start message', () => withMockConsole('log', spy => { //jest test for logStart with helper
   logStart('fn', 1, 2); //trigger log
@@ -20,8 +18,7 @@ test('logReturn logs correct return message', () => withMockConsole('log', spy =
   expect(spy.mock.calls[last][0]).toBe('[RETURN] fn -> "value"'); //check output
 }));
 
-test('executeWithLogs wraps sync function', () => { //jest test for executeWithLogs sync
-  const spy = mockConsole('log'); //replace console.log
+test('executeWithLogs wraps sync function', () => withMockConsole('log', spy => { //jest test for executeWithLogs sync with helper
   function add(a, b){ //simple addition
     return a + b; //return sum
   }
@@ -30,11 +27,9 @@ test('executeWithLogs wraps sync function', () => { //jest test for executeWithL
   expect(spy.mock.calls[1][0]).toBe('add is running with 1, 2'); //check start log
   const last = spy.mock.calls.length - 1; //index of last log
   expect(spy.mock.calls[last][0]).toBe('add is returning 3'); //check return log
-  spy.mockRestore(); //restore console.log
-});
+}));
 
-test('executeWithLogs wraps async function', async () => { //jest test for executeWithLogs async
-  const spy = mockConsole('log'); //replace console.log
+test('executeWithLogs wraps async function', async () => withMockConsole('log', async spy => { //jest test for executeWithLogs async with helper
   async function fetchVal(){ //dummy async
     return 'ok'; //return value
   }
@@ -43,6 +38,5 @@ test('executeWithLogs wraps async function', async () => { //jest test for execu
   expect(spy.mock.calls[1][0]).toBe('fetchVal is running with none'); //check start log
   const last = spy.mock.calls.length - 1; //index of last log
   expect(spy.mock.calls[last][0]).toBe('fetchVal is returning "ok"'); //check return log
-  spy.mockRestore(); //restore console.log
-});
+}));
 


### PR DESCRIPTION
## Summary
- remove direct `mockConsole` import from `logUtils` tests
- wrap sync and async tests with `withMockConsole`

## Testing
- `npx jest --runInBand --silent --json --outputFile=/tmp/results.json`

------
https://chatgpt.com/codex/tasks/task_b_6844a602c35c83228f08bd416eef31c8