### PR TITLE
Refactor setupResolution test helpers

### DIFF
--- a/test/setupResolution.test.js
+++ b/test/setupResolution.test.js
@@ -14,11 +14,11 @@ function runChild(includeSetup){ //(execute child script with or without setup)
 } //(end runChild)
 
 function runWithoutSetup(){ //(spawn child process without setup)
- return executeWithLogs('runWithoutSetup', () => runChild(false)); //(delegate to executeWithLogs)
+ return runChild(false); //(directly return child result without extra logs)
 } //(end runWithoutSetup)
 
 function runWithSetup(){ //(spawn child process with setup)
- return executeWithLogs('runWithSetup', () => runChild(true)); //(delegate to executeWithLogs)
+ return runChild(true); //(directly return child result without extra logs)
 } //(end runWithSetup)
 
 test('child process uses stubs when setup is required', () => { //(jest test case)


### PR DESCRIPTION
## Summary
- simplify runWithoutSetup and runWithSetup helpers
- confirm runChild logs cover both cases

## Testing
- `npx jest --silent`

------
https://chatgpt.com/codex/tasks/task_b_6844a60d2574832282696bc500cf9c77