### PR TITLE
Refactor withMockConsole to use executeWithLogs

### DIFF
--- a/test/mockConsole.test.js
+++ b/test/mockConsole.test.js
@@ -11,7 +11,7 @@ test('mockConsole captures calls and restores', async () => { //verify helper re
     expect(spy.mock.calls[1][0]).toBe('first'); //argument captured correctly
   });
   console.log('second'); //original console after helper cleanup
-  expect(recorded.length).toBe(2); //capture first log and helper return message
+  expect(recorded.length).toBe(1); //capture log inside callback only
 });
 
 test('mockConsole mockImplementation works', () => withMockConsole('log', spy => { //helper handles spy cleanup

--- a/utils/testHelpers.js
+++ b/utils/testHelpers.js
@@ -1,18 +1,15 @@
 const { mockConsole } = require('./mockConsole'); //(import console spy util)
+const { executeWithLogs } = require('../lib/logUtils'); //(import central logging helper)
 
 async function withMockConsole(method, fn){ //(run callback with console spy)
-  console.log(`withMockConsole is running with ${method}`); //(debug start log)
-  const spy = mockConsole(method); //(create console spy)
-  try{ //(run callback safely)
-    const res = await fn(spy); //(execute callback with spy)
-    console.log(`withMockConsole is returning ${res}`); //(debug return log)
-    return res; //(forward result)
-  }catch(err){ //(handle callback error)
-    console.log(`withMockConsole encountered ${err}`); //(log error)
-    throw err; //(rethrow for test failure)
-  }finally{ //(cleanup regardless of outcome)
-    spy.mockRestore(); //(restore original console method)
-  }
+  return executeWithLogs('withMockConsole', async () => { //(central logging wrapper)
+    const spy = mockConsole(method); //(create console spy)
+    try{ //(execute and ensure cleanup)
+      return await fn(spy); //(run provided callback)
+    }finally{ //(always restore spy)
+      spy.mockRestore(); //(restore original console method)
+    }
+  }, method); //(pass method for log context)
 } //(end helper)
 
 module.exports = { withMockConsole }; //(export helper)


### PR DESCRIPTION
## Summary
- centralize logging for `withMockConsole`
- adjust console spy tests to expect new behaviour

## Testing
- `npm test --silent -- --json --outputFile=/tmp/jest.json`

------
https://chatgpt.com/codex/tasks/task_b_6844b3a7cba88322843406b569f87705