### PR TITLE
Export safeSerialize

### DIFF
--- a/lib/logUtils.js
+++ b/lib/logUtils.js
@@ -144,4 +144,4 @@ function executeWithLogs(name, fn, ...args) {
   }
 }
 
-module.exports = { logStart, logReturn, executeWithLogs }; //(export new helper)
+module.exports = { logStart, logReturn, executeWithLogs, safeSerialize }; //(export safeSerialize for direct use)


### PR DESCRIPTION
## Summary
- export the `safeSerialize` utility from logUtils for external use

## Testing
- `npx jest --silent`

------
https://chatgpt.com/codex/tasks/task_b_68450baf63c08322a67f11c415c6324e