### PR TITLE
Fix missing variable and registry end

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -55,6 +55,7 @@ const Module = require('module');
 // Path operations must be cross-platform compatible and handle edge cases
 // like symbolic links, relative paths, and case sensitivity
 const path = require('path');
+const stubsPath = path.join(__dirname, 'stubs'); // (absolute path for stub modules)
 
 /**
  * Module stub registry - defines which modules should be replaced with stubs
@@ -92,7 +93,7 @@ const STUB_REGISTRY = {
 
   // Logging library - redirected to silent stub for clean test output
   'winston': './stubs/winston'
-
+}; // (registry end for stub mappings)
 
   // Additional stubs can be added here following the same pattern:
   // 'module-name': './stubs/module-name'


### PR DESCRIPTION
## Summary
- define `stubsPath` for stub resolution
- close `STUB_REGISTRY` properly

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_b_684523c7cbb883228601a97e694cd18d