### PR TITLE
Add lifecycle helpers

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -56,6 +56,9 @@ const Module = require('module');
 // like symbolic links, relative paths, and case sensitivity
 const path = require('path');
 
+// Calculate absolute path to our stubs directory
+const stubsPath = path.join(__dirname, 'stubs'); //(path to bundled stubs)
+
 /**
  * Module stub registry - defines which modules should be replaced with stubs
  * 
@@ -92,10 +95,10 @@ const STUB_REGISTRY = {
 
   // Logging library - redirected to silent stub for clean test output
   'winston': './stubs/winston'
+}; //(close registry mapping)
 
-
-  // Additional stubs can be added here following the same pattern:
-  // 'module-name': './stubs/module-name'
+// Additional stubs can be added here following the same pattern:
+// 'module-name': './stubs/module-name'
 
 // Preserve existing NODE_PATH if it exists
 // Some environments or tools may have already set NODE_PATH
@@ -116,8 +119,6 @@ process.env.NODE_PATH = stubsPath + (currentNodePath ? separator + currentNodePa
 // We must call this to apply our changes mid-execution
 // This updates Module._nodeModulePaths and other internal state
 require('module')._initPaths();
-
-const Module = require('module'); //(import module constructor for loader override)
 const origLoad = Module._load; //(store original load function)
 const stubMap = { axios: 'axios.js', winston: 'winston.js' }; //(map of stub files for quick lookup, extend with additional stubs as needed)
 Module._load = function(request, parent, isMain){ //(override to redirect specific modules)


### PR DESCRIPTION
## Summary
- wrap console tests with `withMockConsole`
- add `withSavedEnv` helper for env isolation
- reload offline mode correctly in `stubQerrors`
- fix stub registry format in setup

## Testing
- `npx jest --runInBand --json --outputFile=/tmp/result.json >/tmp/null`


------
https://chatgpt.com/codex/tasks/task_b_684523c895ac83229f74166182aa87d9