### PR TITLE
Clean up test env helpers

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -55,6 +55,7 @@ const Module = require('module');
 // Path operations must be cross-platform compatible and handle edge cases
 // like symbolic links, relative paths, and case sensitivity
 const path = require('path');
+const stubsPath = path.join(__dirname, "stubs");
 
 /**
  * Module stub registry - defines which modules should be replaced with stubs
@@ -96,6 +97,7 @@ const STUB_REGISTRY = {
 
   // Additional stubs can be added here following the same pattern:
   // 'module-name': './stubs/module-name'
+};
 
 // Preserve existing NODE_PATH if it exists
 // Some environments or tools may have already set NODE_PATH
@@ -117,7 +119,6 @@ process.env.NODE_PATH = stubsPath + (currentNodePath ? separator + currentNodePa
 // This updates Module._nodeModulePaths and other internal state
 require('module')._initPaths();
 
-const Module = require('module'); //(import module constructor for loader override)
 const origLoad = Module._load; //(store original load function)
 const stubMap = { axios: 'axios.js', winston: 'winston.js' }; //(map of stub files for quick lookup, extend with additional stubs as needed)
 Module._load = function(request, parent, isMain){ //(override to redirect specific modules)


### PR DESCRIPTION
## Summary
- define `defaultEnv` at top-level for tests
- rewrite `setTestEnv` and env restore helpers
- implement helpers for axios, qerrors, schedule mocks and test init
- close stub registry and add missing `stubsPath` in setup

## Testing
- `npm test` *(fails: withMockConsole is not a function)*

------
https://chatgpt.com/codex/tasks/task_b_684523c7cb888322bf2a3c5a77cb158f