### PR TITLE
Fix duplicate stubsPath

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -55,10 +55,9 @@ const Module = require('module');
 // Path operations must be cross-platform compatible and handle edge cases
 // like symbolic links, relative paths, and case sensitivity
 const path = require('path');
-const stubsPath = path.join(__dirname, 'stubs'); // (absolute path for stub modules)
+const stubsPath = path.join(__dirname, 'stubs'); // (single absolute path for stub modules after duplicate removal)
 
-// Calculate absolute path to our stubs directory
-const stubsPath = path.join(__dirname, 'stubs'); //(path to bundled stubs)
+// path to stubs directory resolved above //(single comment after removal)
 
 /**
  * Module stub registry - defines which modules should be replaced with stubs


### PR DESCRIPTION
## Summary
- remove duplicated `stubsPath` declaration in setup.js
- add comment about duplicate removal

## Testing
- `node -c setup.js`

------
https://chatgpt.com/codex/tasks/task_b_6845286493888322a83066e8f2e5464e