### PR TITLE
Remove mid-block console restore

### DIFF
--- a/test/mockConsole.test.js
+++ b/test/mockConsole.test.js
@@ -11,7 +11,7 @@ test('mockConsole captures calls and restores', async () => { //verify helper re
     expect(spy.mock.calls[1][0]).toBe('first'); //argument captured correctly
   });
   console.log('second'); //original console after helper cleanup
-  expect(recorded.length).toBe(1); //capture log inside callback only
+  expect(recorded.length).toBe(2); //new expectation includes helper log
 });
 
 test('mockConsole mockImplementation works', () => withMockConsole('log', spy => { //helper handles spy cleanup

--- a/utils/testHelpers.js
+++ b/utils/testHelpers.js
@@ -198,8 +198,7 @@ async function withMockConsole(method, fn) {
   console.log(`withMockConsole is running with ${method}`); //(log after spy setup)
   try {
     const result = await fn(spy);
-    spy.mockRestore();
-    console.log(`withMockConsole is returning ${result}`); //(log after restore)
+    console.log(`withMockConsole is returning ${result}`); //(log before restore moved to finally)
     return result;
   } catch (err) {
     console.log(`withMockConsole error ${err.message}`);


### PR DESCRIPTION
## Summary
- streamline `withMockConsole` cleanup to restore the spy only in `finally`
- update tests to match new logging behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68452a6f606883229d68b208840ec43f