### PR TITLE
Add safeSerialize tests

### DIFF
--- a/test/safeSerialize.test.js
+++ b/test/safeSerialize.test.js
@@ -1,0 +1,23 @@
+const { safeSerialize } = require('../lib/logUtils'); //import serializer under test
+const util = require('util'); //node util for expected output
+
+test('serializes primitives and objects', () => { //verify JSON path
+  expect(safeSerialize(5)).toBe('5'); //number serialization
+  expect(safeSerialize('hi')).toBe('"hi"'); //string serialization
+  const obj = { a: 1 }; //simple object
+  expect(safeSerialize(obj)).toBe(JSON.stringify(obj)); //object serialization output
+});
+
+test('falls back to util.inspect for circular references', () => { //verify fallback
+  const circ = {}; //create base object
+  circ.self = circ; //circular reference
+  const expected = util.inspect(circ, { depth: null }); //expected inspect
+  expect(safeSerialize(circ)).toBe(expected); //uses inspect output
+});
+
+test('returns "[unserializable]" on inspect failure', () => { //verify final fallback
+  const bad = {}; //object that forces errors
+  bad.toJSON = () => { throw new Error('json fail'); }; //stringify will throw
+  bad[util.inspect.custom] = () => { throw new Error('inspect fail'); }; //inspect will throw
+  expect(safeSerialize(bad)).toBe('[unserializable]'); //fallback result string
+});

--- a/test/testSetup.js
+++ b/test/testSetup.js
@@ -1,1 +1,2 @@
+try{ require('qtests/setup'); }catch{} //(attempt package setup without failing)
 require('..').setup(); // (activate stub resolution for jest)


### PR DESCRIPTION
## Summary
- test safeSerialize for JSON output, inspect fallback, and final placeholder
- call `qtests/setup` in test setup so repo works like installed package

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68457f237c348322a64041f3129cd61f