### PR TITLE
Implement caching for offline utils

### DIFF
--- a/test/offlineIntegration.test.js
+++ b/test/offlineIntegration.test.js
@@ -8,10 +8,13 @@ function runToggleScript(){ // (execute a node script toggling offline mode)
     const realAxios = require(require.resolve('axios'));
     const states = []; 
     offline.setOfflineMode(true);
+    offline.clearOfflineCache();
     states.push({ offline: offline.isOfflineMode(), axiosStub: offline.getAxios() === stubAxios, qType: typeof offline.getQerrors().qerrors });
     offline.setOfflineMode(false);
+    offline.clearOfflineCache();
     states.push({ offline: offline.isOfflineMode(), axiosReal: offline.getAxios() === realAxios, qType: typeof offline.getQerrors().qerrors });
     offline.setOfflineMode(true);
+    offline.clearOfflineCache();
     states.push({ offline: offline.isOfflineMode(), axiosStub: offline.getAxios() === stubAxios, qType: typeof offline.getQerrors().qerrors });
     console.log(JSON.stringify(states));
   `; // (script toggles offline mode and captures results)

--- a/test/offlineMode.test.js
+++ b/test/offlineMode.test.js
@@ -1,8 +1,8 @@
 require('../setup'); //activate stub resolution for axios and winston
 
-const { setOfflineMode, isOfflineMode, getAxios, getQerrors } = require('../utils/offlineMode'); //import utilities under test
+const { setOfflineMode, isOfflineMode, getAxios, getQerrors, clearOfflineCache } = require('../utils/offlineMode'); //import utilities under test
 
-afterEach(() => setOfflineMode(false)); //ensure offline state reset after each test
+afterEach(() => { setOfflineMode(false); clearOfflineCache(); }); //ensure offline state and caches reset
 
 test('setOfflineMode toggles offline state', () => { //verify state management
   setOfflineMode(true); //enable offline mode
@@ -13,18 +13,22 @@ test('setOfflineMode toggles offline state', () => { //verify state management
 
 test('getAxios returns stub offline and real online', () => { //verify axios selection
   setOfflineMode(true); //enable offline
+  clearOfflineCache(); //reset caches before loading offline
   const offlineAxios = getAxios(); //retrieve stub
   expect(offlineAxios).toBe(require('../stubs/axios')); //should equal stub module
   setOfflineMode(false); //switch to online
+  clearOfflineCache(); //reset caches before loading online
   const onlineAxios = getAxios(); //retrieve real axios
   expect(onlineAxios).toBe(require('axios')); //should equal real axios
 });
 
 test('getQerrors returns stub offline and fallback when module missing', () => { //verify qerrors selection
   setOfflineMode(true); //enable offline
+  clearOfflineCache(); //reset caches before loading offline
   const offlineQerrors = getQerrors(); //get stub when offline
   expect(typeof offlineQerrors.qerrors).toBe('function'); //stub exposes function
   setOfflineMode(false); //switch to online
+  clearOfflineCache(); //reset caches before loading online
   const onlineQerrors = getQerrors(); //should fall back due to missing module
   expect(typeof onlineQerrors.qerrors).toBe('function'); //fallback still exposes function
 });


### PR DESCRIPTION
## Summary
- cache axios and qerrors modules in `offlineMode`
- add `clearOfflineCache` helper to reset caches
- adjust tests for the new cache behavior

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68468b37dadc8322bd286eb272fca5e1