### PR TITLE
Add optional logging toggle

### DIFF
--- a/lib/logUtils.js
+++ b/lib/logUtils.js
@@ -22,6 +22,12 @@
 // Import util for safe inspection fallback //(new dependency)
 const util = require('util'); //(require util module)
 
+let LOG_ENABLED = true; //(global log flag default true)
+
+function setLogging(enabled){ //(setter to toggle global logs)
+  LOG_ENABLED = enabled; //(update flag state)
+}
+
 /**
  * Safely converts values to strings for logging
  *
@@ -74,7 +80,7 @@ function logStart(functionName, ...args) {
   
   // Log with consistent format: [START] functionName(arg1, arg2, ...)
   // This format is easy to parse and grep for debugging
-  console.log(`[START] ${functionName}(${argsString})`);
+  if (LOG_ENABLED) console.log(`[START] ${functionName}(${argsString})`); //(log if enabled)
 }
 
 /**
@@ -105,7 +111,7 @@ function logReturn(functionName, returnValue) {
   
   // Log with consistent format: [RETURN] functionName -> returnValue
   // Arrow notation clearly indicates this is a return value
-  console.log(`[RETURN] ${functionName} -> ${valueString}`);
+  if (LOG_ENABLED) console.log(`[RETURN] ${functionName} -> ${valueString}`); //(log if enabled)
 }
 
 // Export both functions for use throughout the qtests module
@@ -124,24 +130,24 @@ function logReturn(functionName, returnValue) {
  */
 function executeWithLogs(name, fn, ...args) {
   const argString = args.length ? args.map(a => safeSerialize(a)).join(', ') : 'none'; //(serialize arguments)
-  console.log(`${name} is running with ${argString}`); //(start log)
+  if (LOG_ENABLED) console.log(`${name} is running with ${argString}`); //(start log if enabled)
   try{ // (wrap callback execution)
     const result = fn(...args); //(invoke callback)
     if (result && typeof result.then === 'function') { // (handle promise result)
       return result.then(res => { // (await async resolution)
-        console.log(`${name} is returning ${safeSerialize(res)}`); //(async return log)
+        if (LOG_ENABLED) console.log(`${name} is returning ${safeSerialize(res)}`); //(async return log if enabled)
         return res; //(forward async result)
       }).catch(err => { // (async error path)
-        console.log(`${name} encountered ${err.message}`); //(async error log)
+        if (LOG_ENABLED) console.log(`${name} encountered ${err.message}`); //(async error log if enabled)
         throw err; //(rethrow async error)
       });
     }
-    console.log(`${name} is returning ${safeSerialize(result)}`); //(sync return log)
+    if (LOG_ENABLED) console.log(`${name} is returning ${safeSerialize(result)}`); //(sync return log if enabled)
     return result; //(return sync result)
   }catch(error){ // (sync error path)
-    console.log(`${name} encountered ${error.message}`); //(sync error log)
+    if (LOG_ENABLED) console.log(`${name} encountered ${error.message}`); //(sync error log if enabled)
     throw error; //(rethrow sync error)
   }
 }
 
-module.exports = { logStart, logReturn, executeWithLogs, safeSerialize }; //(export safeSerialize for direct use)
+module.exports = { logStart, logReturn, executeWithLogs, safeSerialize, setLogging }; //(export setLogging for external control)

--- a/utils/offlineMode.js
+++ b/utils/offlineMode.js
@@ -26,7 +26,8 @@
  */
 
 // Import logging utilities for consistent debugging output
-const { logStart, logReturn } = require('../lib/logUtils');
+const { logStart, logReturn, setLogging } = require('../lib/logUtils'); //(import setLogging)
+if (process.env.NODE_ENV !== 'test') setLogging(false); //(mute logs outside tests)
 
 // Initialize offline mode state - starts in online mode by default
 // This state determines whether to use real or stub implementations

--- a/utils/testEnv.js
+++ b/utils/testEnv.js
@@ -20,7 +20,8 @@
  */
 
 // Import logging utilities including wrapper for consistent logs
-const { logStart, logReturn, executeWithLogs } = require('../lib/logUtils'); //(add executeWithLogs and retain existing helpers)
+const { logStart, logReturn, executeWithLogs, setLogging } = require('../lib/logUtils'); //(import setLogging for optional disable)
+if (process.env.NODE_ENV !== 'test') setLogging(false); //(mute logs outside tests)
 
 const defaultEnv = { // (shared env defaults for tests)
   GOOGLE_API_KEY: 'key', // (fake google api key)


### PR DESCRIPTION
## Summary
- add global LOG_ENABLED flag in `logUtils`
- export `setLogging` to toggle logging
- wrap logging statements with flag checks
- allow environment utilities to disable logs when NODE_ENV isn't 'test'

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_68468b476b80832283117734a864527e