### PR TITLE
Implement configurable inspect depth

### DIFF
--- a/lib/logUtils.js
+++ b/lib/logUtils.js
@@ -22,6 +22,9 @@
 // Import util for safe inspection fallback //(new dependency)
 const util = require('util'); //(require util module)
 
+// Configuration object controlling util.inspect depth //(exported config)
+const logConfig = { inspectDepth: 2 }; //(default depth of 2)
+
 /**
  * Safely converts values to strings for logging
  *
@@ -37,7 +40,7 @@ function safeSerialize(value) {
     return serialized; //return JSON string without extra logs
   } catch (error) { //handle JSON failure
     try { //attempt util.inspect
-      const inspected = util.inspect(value, { depth: null }); //(inspect fallback)
+      const inspected = util.inspect(value, { depth: logConfig.inspectDepth }); //(inspect fallback uses config depth)
       return inspected; //return inspected string
     } catch (innerErr) { //handle inspect failure
       return '[unserializable]'; //fallback placeholder
@@ -144,4 +147,4 @@ function executeWithLogs(name, fn, ...args) {
   }
 }
 
-module.exports = { logStart, logReturn, executeWithLogs, safeSerialize }; //(export safeSerialize for direct use)
+module.exports = { logStart, logReturn, executeWithLogs, safeSerialize, logConfig }; //(export safeSerialize & config)

--- a/test/safeSerialize.test.js
+++ b/test/safeSerialize.test.js
@@ -1,4 +1,4 @@
-const { safeSerialize } = require('../lib/logUtils'); //import serializer under test
+const { safeSerialize, logConfig } = require('../lib/logUtils'); //import serializer and config under test
 const util = require('util'); //node util for expected output
 
 test('serializes primitives and objects', () => { //verify JSON path
@@ -11,7 +11,7 @@ test('serializes primitives and objects', () => { //verify JSON path
 test('falls back to util.inspect for circular references', () => { //verify fallback
   const circ = {}; //create base object
   circ.self = circ; //circular reference
-  const expected = util.inspect(circ, { depth: null }); //expected inspect
+  const expected = util.inspect(circ, { depth: logConfig.inspectDepth }); //expected inspect with config depth
   expect(safeSerialize(circ)).toBe(expected); //uses inspect output
 });
 
@@ -20,4 +20,13 @@ test('returns "[unserializable]" on inspect failure', () => { //verify final fal
   bad.toJSON = () => { throw new Error('json fail'); }; //stringify will throw
   bad[util.inspect.custom] = () => { throw new Error('inspect fail'); }; //inspect will throw
   expect(safeSerialize(bad)).toBe('[unserializable]'); //fallback result string
+});
+
+test('logConfig controls inspect depth', () => { //verify configurable depth
+  const deepObj = { level1: { level2: { level3: 'value' } } }; //nested object
+  deepObj.level1.level2.self = deepObj.level1; //create circular reference for inspect fallback
+  logConfig.inspectDepth = 1; //set depth to 1
+  const expected = util.inspect(deepObj, { depth: logConfig.inspectDepth }); //expected output with depth 1
+  expect(safeSerialize(deepObj)).toBe(expected); //serializer respects config
+  logConfig.inspectDepth = 2; //reset depth after test
 });


### PR DESCRIPTION
## Summary
- add `logConfig.inspectDepth` for util.inspect configuration
- update `safeSerialize` to use configurable depth
- test configurable inspect depth in safeSerialize tests

## Testing
- `npx --no-install jest --runInBand --colors=false`

------
https://chatgpt.com/codex/tasks/task_b_68468b4c43348322954b8ff50c518fb4