### PR TITLE
Fix safeSerialize undefined handling

### DIFF
--- a/lib/logUtils.js
+++ b/lib/logUtils.js
@@ -38,16 +38,19 @@ function setLogging(enabled){ //(setter to toggle global logs)
  * @returns {string} Serialized representation
  */
 function safeSerialize(value) {
+  if (value === undefined) return 'undefined'; // handle undefined explicitly for clarity
   try {
     // Attempt JSON serialization as primary strategy for most values
     // JSON.stringify chosen first because it produces clean, readable output
     // Handles primitive types, arrays, and plain objects efficiently
-    // Fails gracefully on circular references, functions, symbols, undefined
+    // Fails gracefully on circular references, functions, symbols
     const serialized = JSON.stringify(value);
-    return serialized;
+    if (serialized !== undefined) return serialized; // check for unsupported types
+    const inspected = util.inspect(value, { depth: null }); // fallback for functions or symbols
+    return inspected;
   } catch (error) {
     // Handle JSON serialization failures with util.inspect fallback
-    // Common failures: circular references, functions, symbols, BigInt
+    // Common failures: circular references, BigInt
     try {
       // Use util.inspect for complex objects that JSON.stringify cannot handle
       // depth: null ensures complete object traversal without truncation

--- a/test/comprehensive.test.js
+++ b/test/comprehensive.test.js
@@ -17,7 +17,7 @@ describe('Additional qtests Coverage', () => {
 
   test('safeSerialize handles edge cases', () => {
     expect(safeSerialize(null)).toBe('null');
-    expect(typeof safeSerialize(undefined)).toBe('string');
+    expect(safeSerialize(undefined)).toBe('undefined'); // updated expectation for explicit undefined handling
     expect(safeSerialize('string')).toBe('"string"');
     expect(safeSerialize(123)).toBe('123');
   });

--- a/test/safeSerialize.test.js
+++ b/test/safeSerialize.test.js
@@ -8,6 +8,10 @@ test('serializes primitives and objects', () => { //verify JSON path
   expect(safeSerialize(obj)).toBe(JSON.stringify(obj)); //object serialization output
 });
 
+test('handles undefined value', () => { //new test for explicit undefined handling
+  expect(safeSerialize(undefined)).toBe('undefined'); //should return string literal
+});
+
 test('falls back to util.inspect for circular references', () => { //verify fallback
   const circ = {}; //create base object
   circ.self = circ; //circular reference


### PR DESCRIPTION
## Summary
- handle `undefined` explicitly in `safeSerialize`
- update comprehensive test expectation
- add unit test for undefined case

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6848d39d7f348322be0ead274c1ba701