### PR TITLE
Implement reload locking mechanism

### DIFF
--- a/lib/logUtils.js
+++ b/lib/logUtils.js
@@ -42,26 +42,21 @@ function safeSerialize(value) {
     // Attempt JSON serialization as primary strategy for most values
     // JSON.stringify chosen first because it produces clean, readable output
     // Handles primitive types, arrays, and plain objects efficiently
-    // Fails gracefully on circular references, functions, symbols, undefined
+    // Returns undefined for values like functions and undefined
     const serialized = JSON.stringify(value);
-    return serialized;
+    if (serialized !== undefined) return serialized; //ensure string result
   } catch (error) {
-    // Handle JSON serialization failures with util.inspect fallback
-    // Common failures: circular references, functions, symbols, BigInt
-    try {
-      // Use util.inspect for complex objects that JSON.stringify cannot handle
-      // depth: null ensures complete object traversal without truncation
-      // util.inspect handles circular references, functions, and Node.js-specific objects
-      // Produces more verbose but complete representation of complex values
-      const inspected = util.inspect(value, { depth: null });
-      return inspected;
-    } catch (innerErr) {
-      // Final fallback for truly unserializable values
-      // Rare cases where both JSON.stringify and util.inspect fail
-      // Provides consistent placeholder rather than throwing error
-      // Ensures logging never fails due to argument serialization issues
-      return '[unserializable]';
-    }
+    // JSON.stringify can throw on complex structures like circular references
+  }
+
+  try {
+    // Fallback to util.inspect for complex objects or undefined values
+    // depth: null ensures complete object traversal without truncation
+    const inspected = util.inspect(value, { depth: null });
+    return inspected;
+  } catch (innerErr) {
+    // Final safeguard when both serialization attempts fail
+    return '[unserializable]';
   }
 }
 


### PR DESCRIPTION
## Summary
- prevent concurrent module reloads with a lock
- expose the lock for tests and add concurrency test
- adjust `safeSerialize` to always return a string

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6848d3a341448322b14dafa3770ef70c