### PR TITLE
Add input validation in stubMethod

### DIFF
--- a/lib/logUtils.js
+++ b/lib/logUtils.js
@@ -43,7 +43,8 @@ function safeSerialize(value) {
     // JSON.stringify chosen first because it produces clean, readable output
     // Handles primitive types, arrays, and plain objects efficiently
     // Fails gracefully on circular references, functions, symbols, undefined
-    const serialized = JSON.stringify(value);
+    const serialized = JSON.stringify(value); //stringify value for clean output
+    if (serialized === undefined) return String(value); //handle undefined & functions cleanly
     return serialized;
   } catch (error) {
     // Handle JSON serialization failures with util.inspect fallback

--- a/test/stubMethod.test.js
+++ b/test/stubMethod.test.js
@@ -8,3 +8,9 @@ test('stubMethod replaces and restores methods', () => { // (jest test case)
   expect(result).toBe('Hi'); // (assert stub result)
   expect(obj.greet('Bob')).toBe('Hello, Bob'); // (assert restoration works)
 });
+
+test('stubMethod validates inputs', () => { // (ensure TypeErrors are thrown for invalid input)
+  expect(() => stubMethod(null, 'greet', () => {})).toThrow(TypeError); // (obj must be an object)
+  expect(() => stubMethod({}, 123, () => {})).toThrow(TypeError); // (method name must be string)
+  expect(() => stubMethod({}, 'missing', () => {})).toThrow(TypeError); // (property must exist)
+});

--- a/utils/stubMethod.js
+++ b/utils/stubMethod.js
@@ -62,8 +62,11 @@
  */
 function stubMethod(obj, methodName, stubFn) {
   console.log(`stubMethod is running with ${obj}, ${methodName}, ${stubFn}`); // logging function start per requirements
-  
+
   try {
+    if (typeof obj !== 'object' || obj === null) { throw new TypeError('stubMethod expected obj to be an object'); } //validate obj parameter
+    if (typeof methodName !== 'string') { throw new TypeError('stubMethod expected methodName to be a string'); } //validate method name type
+    if (!Object.prototype.hasOwnProperty.call(obj, methodName)) { throw new TypeError('stubMethod expected methodName to reference an existing property'); } //ensure property exists
     // Store original method reference before replacement
     // This is critical for restoration - without this reference, the original method is lost forever
     // We must capture this before any modification to ensure we can restore exact original behavior


### PR DESCRIPTION
## Summary
- throw descriptive errors when `stubMethod` input is invalid
- test that invalid parameters throw `TypeError`
- ensure `safeSerialize` stringifies `undefined`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6848d3a74a008322bd79da557a555c02