### PR TITLE
Add repeated setup() test

### DIFF
--- a/test/setupMultiple.test.js
+++ b/test/setupMultiple.test.js
@@ -1,0 +1,13 @@
+const { execFileSync } = require('child_process'); //child process runner
+const path = require('path'); //path helper
+
+require('../setup'); //activate stub resolution for test environment
+
+test('setup called twice still returns stubs', () => { //verify repeated setup
+  const scriptPath = path.join(__dirname, 'setupMultipleChild.js'); //child script
+  const output = execFileSync(process.execPath, [scriptPath], { env: { NODE_PATH: '' } }).toString(); //run child script
+  const lastLine = output.trim().split('\n').pop(); //extract JSON line ignoring logs
+  const result = JSON.parse(lastLine); //parse child output
+  expect(result.axiosStub).toBe(true); //axios should resolve to stub
+  expect(result.winstonStub).toBe(true); //winston should resolve to stub
+});

--- a/test/setupMultipleChild.js
+++ b/test/setupMultipleChild.js
@@ -1,0 +1,12 @@
+const { setup } = require('../lib/setup'); //import setup function
+setup(); //first setup invocation
+setup(); //second setup invocation
+const axios = require('axios'); //load axios after setup
+const winston = require('winston'); //load winston after setup
+const stubAxios = require('../stubs/axios'); //reference stub for axios
+const stubWinston = require('../stubs/winston'); //reference stub for winston
+const result = { //prepare result object for parent test
+  axiosStub: axios === stubAxios, //true if axios is stub
+  winstonStub: winston === stubWinston //true if winston is stub
+};
+console.log(JSON.stringify(result)); //output result


### PR DESCRIPTION
## Summary
- add setupMultipleChild.js script to verify that axios and winston are stubbed after multiple setup() calls
- add setupMultiple.test.js running the child script and asserting stub usage

## Testing
- `npx jest test/setupMultiple.test.js --runInBand`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_b_68492032100c8322be0180f9e57ff417