### PR TITLE
Add validation for stubMethod parameters

### DIFF
--- a/test/stubMethod.test.js
+++ b/test/stubMethod.test.js
@@ -8,3 +8,16 @@ test('stubMethod replaces and restores methods', () => { // (jest test case)
   expect(result).toBe('Hi'); // (assert stub result)
   expect(obj.greet('Bob')).toBe('Hello, Bob'); // (assert restoration works)
 });
+
+test('stubMethod throws for non-object target', () => { // verify obj validation
+  expect(() => stubMethod(null, 'greet', () => {})).toThrow('expected object'); // should reject null obj
+});
+
+test('stubMethod throws when method missing', () => { // verify method existence check
+  expect(() => stubMethod({}, 'missing', () => {})).toThrow('could not find'); // should reject absent method
+});
+
+test('stubMethod throws for non-function stub', () => { // verify stubFn validation
+  const obj = { greet: () => 'hi' }; // sample object
+  expect(() => stubMethod(obj, 'greet', 'notFn')).toThrow('must be a function'); // should reject invalid stub
+});

--- a/utils/stubMethod.js
+++ b/utils/stubMethod.js
@@ -62,8 +62,17 @@
  */
 function stubMethod(obj, methodName, stubFn) {
   console.log(`stubMethod is running with ${obj}, ${methodName}, ${stubFn}`); // logging function start per requirements
-  
+
   try {
+    if (typeof obj !== 'object' || obj === null) { // ensure obj is valid before accessing properties
+      throw new Error(`stubMethod expected object but received ${obj}`); // informative error for invalid obj
+    }
+    if (!(methodName in obj)) { // confirm property exists on target object
+      throw new Error(`stubMethod could not find ${methodName} on provided object`); // error when method missing
+    }
+    if (typeof stubFn !== 'function') { // verify stubFn is callable
+      throw new Error('stubMethod stubFn must be a function'); // error when stubFn invalid
+    }
     // Store original method reference before replacement
     // This is critical for restoration - without this reference, the original method is lost forever
     // We must capture this before any modification to ensure we can restore exact original behavior


### PR DESCRIPTION
## Summary
- validate stubMethod parameters are correct
- ensure errors thrown for invalid parameters
- test stubMethod's new validation logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68492b5f4ae083228b4325b3eb778b5b