### PR TITLE
Fix stub resolution paths

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -91,10 +91,10 @@ const stubsPath = path.join(__dirname, 'stubs'); // (single absolute path for st
  */
 const STUB_REGISTRY = {
   // HTTP client library - redirected to no-op stub for network-free testing
-  'axios': './stubs/axios',
+  'axios': './stubs/axios.js', // ensure resolved path includes extension
 
   // Logging library - redirected to silent stub for clean test output
-  'winston': './stubs/winston'
+  'winston': './stubs/winston.js' // ensure resolved path includes extension
 
 }; //(close registry mapping)
 // (registry end for stub mappings)

--- a/test/resolveStubPaths.test.js
+++ b/test/resolveStubPaths.test.js
@@ -1,0 +1,19 @@
+const { execFileSync } = require('child_process'); // spawn child node to avoid jest resolver
+const path = require('path'); // path for stub locations
+
+test('require.resolve returns stub files with extension', () => { // verify stub path resolution
+  console.log(`resolveStubPathTest is running with none`); // start log per guidelines
+  const script = `
+    require('${path.join(__dirname, '../setup')}');
+    const axiosPath = require.resolve('axios');
+    const winstonPath = require.resolve('winston');
+    console.log(JSON.stringify({ axiosPath, winstonPath }));
+  `; // inline script executed with node
+  const out = execFileSync(process.execPath, ['-e', script], { env: { NODE_PATH: '' } }).toString(); // run child script
+  const result = JSON.parse(out.trim().split('\n').pop()); // parse printed JSON
+  const expectedAxios = path.join(__dirname, '../stubs/axios.js'); // expected absolute axios stub path
+  const expectedWinston = path.join(__dirname, '../stubs/winston.js'); // expected absolute winston stub path
+  expect(result.axiosPath).toBe(expectedAxios); // axios should resolve to stub file
+  expect(result.winstonPath).toBe(expectedWinston); // winston should resolve to stub file
+  console.log(`resolveStubPathTest has run resulting in pass`); // end log per guidelines
+});


### PR DESCRIPTION
## Summary
- ensure stub registry entries use `.js` files so require.resolve works
- add regression test verifying require.resolve returns stub files
- test across Node 16, 18 and 20

## Testing
- `nvm use 16 && npm test --silent`
- `nvm use 18 && npm test --silent`
- `nvm use 20 && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_68493aa1f04083228ac00a1e1e948a58