### PR TITLE
Implement cache clearing on offline toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,10 @@ restoreEnvVars(backup); // TEST_VAR removed, original state restored
 ### Offline Mode
 
 ```js
-const { setOfflineMode, clearOfflineCache, getAxios } = require('qtests');
+const { setOfflineMode, getAxios } = require('qtests');
 
 // Enable offline mode
-setOfflineMode(true);
-clearOfflineCache(); // call before requiring modules
+setOfflineMode(true); // caches cleared automatically on toggle
 
 // Get stubbed axios automatically
 const axios = getAxios(); // Returns stub when offline
@@ -162,7 +161,7 @@ Safe environment variable backup and restoration
 #### `getAxios()` / `getQerrors()`
 Returns appropriate stub when offline mode is enabled
 #### `clearOfflineCache()`
-  Call after `setOfflineMode(true/false)` and before requiring modules so axios and qerrors load correctly
+  Manually reset cached axios and qerrors instances when needed; `setOfflineMode` now clears caches automatically
 
 ### Test Helpers
 

--- a/test/offlineIntegration.test.js
+++ b/test/offlineIntegration.test.js
@@ -8,13 +8,10 @@ function runToggleScript(){ // (execute a node script toggling offline mode)
     const realAxios = require(require.resolve('axios'));
     const states = []; 
     offline.setOfflineMode(true);
-    offline.clearOfflineCache();
     states.push({ offline: offline.isOfflineMode(), axiosStub: offline.getAxios() === stubAxios, qType: typeof offline.getQerrors().qerrors });
     offline.setOfflineMode(false);
-    offline.clearOfflineCache();
     states.push({ offline: offline.isOfflineMode(), axiosReal: offline.getAxios() === realAxios, qType: typeof offline.getQerrors().qerrors });
     offline.setOfflineMode(true);
-    offline.clearOfflineCache();
     states.push({ offline: offline.isOfflineMode(), axiosStub: offline.getAxios() === stubAxios, qType: typeof offline.getQerrors().qerrors });
     console.log(JSON.stringify(states));
   `; // (script toggles offline mode and captures results)

--- a/test/offlineMode.test.js
+++ b/test/offlineMode.test.js
@@ -2,7 +2,7 @@ require('../setup'); //activate stub resolution for axios and winston
 
 const { setOfflineMode, isOfflineMode, getAxios, getQerrors, clearOfflineCache } = require('../utils/offlineMode'); //import utilities under test
 
-afterEach(() => { setOfflineMode(false); clearOfflineCache(); }); //ensure offline state and caches reset
+afterEach(() => { setOfflineMode(false); clearOfflineCache(); }); //ensure offline state reset; caches cleared for test isolation
 
 test('setOfflineMode toggles offline state', () => { //verify state management
   setOfflineMode(true); //enable offline mode
@@ -12,35 +12,30 @@ test('setOfflineMode toggles offline state', () => { //verify state management
 });
 
 test('getAxios returns stub offline and real online', () => { //verify axios selection
-  setOfflineMode(true); //enable offline
-  clearOfflineCache(); //reset caches before loading offline
-  const offlineAxios = getAxios(); //retrieve stub
+  setOfflineMode(true); //enable offline; cache cleared automatically
+  const offlineAxios = getAxios(); //retrieve stub after toggle
   expect(offlineAxios).toBe(require('../stubs/axios')); //should equal stub module
-  setOfflineMode(false); //switch to online
-  clearOfflineCache(); //reset caches before loading online
-  const onlineAxios = getAxios(); //retrieve real axios
+  setOfflineMode(false); //switch to online; cache cleared automatically
+  const onlineAxios = getAxios(); //retrieve real axios after toggle
   expect(onlineAxios).toBe(require('axios')); //should equal real axios
 });
 
 test('getQerrors returns stub offline and fallback when module missing', () => { //verify qerrors selection
-  setOfflineMode(true); //enable offline
-  clearOfflineCache(); //reset caches before loading offline
+  setOfflineMode(true); //enable offline; cache cleared automatically
   const offlineQerrors = getQerrors(); //get stub when offline
   expect(typeof offlineQerrors.qerrors).toBe('function'); //stub exposes function
-  setOfflineMode(false); //switch to online
-  clearOfflineCache(); //reset caches before loading online
+  setOfflineMode(false); //switch to online; cache cleared automatically
   const onlineQerrors = getQerrors(); //should fall back due to missing module
   expect(typeof onlineQerrors.qerrors).toBe('function'); //fallback still exposes function
 });
 
-test('clearOfflineCache refreshes instances on mode toggle', () => { //verify cache reset behaviour
+test('setOfflineMode automatically clears caches on toggle', () => { //verify automatic cache clearing
   setOfflineMode(true); //start offline
   const axiosFirst = getAxios(); //fetch stub instance
   const qerrorsFirst = getQerrors(); //fetch qerrors stub
-  setOfflineMode(false); //toggle to online
-  clearOfflineCache(); //wipe cached modules
+  setOfflineMode(false); //toggle to online triggers cache clear automatically
   const axiosSecond = getAxios(); //fetch new axios
   const qerrorsSecond = getQerrors(); //fetch new qerrors
-  expect(axiosSecond).not.toBe(axiosFirst); //axios should be different
-  expect(qerrorsSecond).not.toBe(qerrorsFirst); //qerrors should be different
+  expect(axiosSecond).not.toBe(axiosFirst); //axios should be different after toggle
+  expect(qerrorsSecond).not.toBe(qerrorsFirst); //qerrors should be different after toggle
 });

--- a/utils/offlineMode.js
+++ b/utils/offlineMode.js
@@ -67,9 +67,11 @@ let qerrorsCache; // (cache for qerrors module)
  */
 function setOfflineMode(offline) {
   console.log(`setOfflineMode is running with ${offline}`); // logging function start per requirements
-  
+
   try {
+    const stateChanged = isOffline !== offline; // check if state differs to know when to clear cache
     isOffline = offline; // update global offline state flag
+    if (stateChanged) clearOfflineCache(); // wipe caches when toggling state for consistent modules
     console.log(`setOfflineMode is returning ${isOffline}`); // logging return value per requirements
     return isOffline;
   } catch (error) {


### PR DESCRIPTION
## Summary
- refresh axios/qerrors caches automatically on `setOfflineMode`
- adjust offline mode docs for new behavior
- simplify offline mode integration tests
- validate cache clearing logic in unit tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6849c587df48832289ba7bec65375c1e