### PR TITLE
Fix restore for inherited methods

### DIFF
--- a/test/stubMethod.test.js
+++ b/test/stubMethod.test.js
@@ -21,3 +21,13 @@ test('stubMethod throws for non-function stub', () => { // verify stubFn validat
   const obj = { greet: () => 'hi' }; // sample object
   expect(() => stubMethod(obj, 'greet', 'notFn')).toThrow('must be a function'); // should reject invalid stub
 });
+
+test('stubMethod handles inherited methods', () => { // new test for prototype restoration
+  const proto = { greet: () => 'proto' }; // prototype with method
+  const obj = Object.create(proto); // object inheriting greet
+  const restore = stubMethod(obj, 'greet', () => 'stub'); // stub inherited method
+  expect(obj.greet()).toBe('stub'); // stub in effect
+  restore(); // restore should remove own property
+  expect(Object.prototype.hasOwnProperty.call(obj, 'greet')).toBe(false); // stub removed
+  expect(obj.greet()).toBe('proto'); // inherited method available again
+});

--- a/utils/stubMethod.js
+++ b/utils/stubMethod.js
@@ -76,7 +76,8 @@ function stubMethod(obj, methodName, stubFn) {
     // Store original method reference before replacement
     // This is critical for restoration - without this reference, the original method is lost forever
     // We must capture this before any modification to ensure we can restore exact original behavior
-    const originalMethod = obj[methodName];
+    const originalMethod = obj[methodName]; // capture original reference
+    const hadOwn = Object.prototype.hasOwnProperty.call(obj, methodName); // track if property was own before stubbing
     
     // Replace method directly on the object for immediate effect
     // Direct property assignment chosen over Object.defineProperty for simplicity and performance
@@ -88,10 +89,12 @@ function stubMethod(obj, methodName, stubFn) {
     // Named function 'restore' provides clear intent and better debugging experience
     // Returned function pattern allows caller to control when restoration occurs
     const restoreFunction = function restore() {
-      // Reinstate original method implementation exactly as it was
-      // Simple assignment chosen over complex descriptor restoration for reliability
-      // This approach ensures no side effects or partial restoration states
-      obj[methodName] = originalMethod;
+      // Reinstate original method only if it existed as own property, otherwise remove stub
+      if (hadOwn) { // property was originally own so simply reassign
+        obj[methodName] = originalMethod; // restore exact original method
+      } else {
+        delete obj[methodName]; // remove stub so prototype chain resolves original
+      }
     };
     
     console.log(`stubMethod is returning ${restoreFunction}`); // logging return value per requirements


### PR DESCRIPTION
## Summary
- handle inherited properties in `stubMethod`
- test that inherited methods restore properly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6849c588f0208322aa5ebb190f0999aa